### PR TITLE
Addition of License header and Copyright notice

### DIFF
--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  SETTINGS
  */

--- a/src/components/_badge.scss
+++ b/src/components/_badge.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  BADGE
  *

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  BUTTON
  *

--- a/src/components/_forms.scss
+++ b/src/components/_forms.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  FORMS
  *

--- a/src/components/_loading-bar.scss
+++ b/src/components/_loading-bar.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  LOADING BAR
  *

--- a/src/components/_loading-spinner.scss
+++ b/src/components/_loading-spinner.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  LOADING SPINNER
  *

--- a/src/components/_notification.scss
+++ b/src/components/_notification.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  NOTIFICATION
  *

--- a/src/components/_paginator.scss
+++ b/src/components/_paginator.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  PAGINATOR
  *

--- a/src/components/_table.scss
+++ b/src/components/_table.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  TABLE
  *

--- a/src/components/_tabs.scss
+++ b/src/components/_tabs.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  TABS
  *

--- a/src/components/_tag.scss
+++ b/src/components/_tag.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  TAG
  *

--- a/src/grid/_grid-framework.scss
+++ b/src/grid/_grid-framework.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 // Framework grid generation
 //
 // Used only by Bootstrap to generate the correct number of grid classes given

--- a/src/grid/_grid.scss
+++ b/src/grid/_grid.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /// Grid system
 //
 // Generate semantic grid columns with these mixins.

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 @charset 'UTF-8';
 
 // Settings

--- a/src/utils/_aligner.scss
+++ b/src/utils/_aligner.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  ALIGNERS
  */

--- a/src/utils/_background.scss
+++ b/src/utils/_background.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  BACKGROUND
  */

--- a/src/utils/_border.scss
+++ b/src/utils/_border.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  BORDER
  */

--- a/src/utils/_breakpoints.scss
+++ b/src/utils/_breakpoints.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 // Breakpoint viewport sizes and media queries.
 //
 // Breakpoints are defined as a map of (name: minimum width), order from small to large:

--- a/src/utils/_default.scss
+++ b/src/utils/_default.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  MAIN RULES
  */

--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 // Container widths
 //
 // Set the container width, and override it for fixed navbars in media queries.

--- a/src/utils/_helpers.scss
+++ b/src/utils/_helpers.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  FLOATS
  */

--- a/src/utils/_layout.scss
+++ b/src/utils/_layout.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * LAYOUT
  */

--- a/src/utils/_reset.scss
+++ b/src/utils/_reset.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * Reset
  */

--- a/src/utils/_typography.scss
+++ b/src/utils/_typography.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2015-2019 Joan Claret and contributors
+ *
+ * This file is part of Sierra.
+ *
+ * Sierra is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Sierra is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sierra.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  *  TYPOGRAPHY
  */


### PR DESCRIPTION
This PR is meant to solve the issue #68 by adding a proper GPL-2.0 license header with copyright notices for `Joan Claret and contributors`. The specific license identifier is `GPL-2.0-or-later`, as the header indicates the possibility of using this library with other GPL code, which may be licensed under newer versions of the GPL.