### PR TITLE
Fix .clearfix to not affect all child elements of this container

### DIFF
--- a/src/utils/_helpers.scss
+++ b/src/utils/_helpers.scss
@@ -11,7 +11,7 @@
 }
 
 .clearfix {
-  ::after {
+  &::after {
     clear: both;
     content: '';
     display: table;


### PR DESCRIPTION
The current .clearfix style will apply the pseudo-element to all children, this needs to be fixed.